### PR TITLE
Add progress bars for downloading and extraction

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,8 @@
 module github.com/ktorio/ktor-cli
 
 go 1.21.1
+
+require (
+	golang.org/x/sys v0.23.0 // indirect
+	golang.org/x/term v0.23.0 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,4 @@
+golang.org/x/sys v0.23.0 h1:YfKFowiIMvtgl1UERQoTPPToxltDeZfbj4H7dVUCwmM=
+golang.org/x/sys v0.23.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
+golang.org/x/term v0.23.0 h1:F6D4vR+EHoL9/sWAWgAR1H2DcHr4PareCbAaCo1RpuU=
+golang.org/x/term v0.23.0/go.mod h1:DgV24QBUrK6jhZXl+20l6UWznPlwAHm1Q1mGHtydmSk=

--- a/internal/app/cli/jdk.go
+++ b/internal/app/cli/jdk.go
@@ -12,7 +12,6 @@ import (
 )
 
 func DownloadJdk(homeDir string, client *http.Client, logger *log.Logger, attempt int) (string, error) {
-	fmt.Println("Downloading JDK...")
 	jdkPath, err := jdk.FetchRecommendedJdk(client, homeDir, logger)
 
 	if err != nil {

--- a/internal/app/jdk/download.go
+++ b/internal/app/jdk/download.go
@@ -4,6 +4,8 @@ import (
 	"errors"
 	"fmt"
 	"github.com/ktorio/ktor-cli/internal/app"
+	"github.com/ktorio/ktor-cli/internal/app/progress"
+	"github.com/ktorio/ktor-cli/internal/app/utils"
 	"io"
 	"log"
 	"net/http"
@@ -36,7 +38,9 @@ func DownloadJdk(client *http.Client, d *Descriptor, logger *log.Logger) ([]byte
 		}
 	}
 
-	return io.ReadAll(resp.Body)
+	reader, progressBar := progress.NewReader(resp.Body, "Downloading JDK... ", utils.ContentLength(resp), true)
+	defer progressBar.Finish()
+	return io.ReadAll(reader)
 }
 
 func hasJdkBuild(d *Descriptor) bool {

--- a/internal/app/network/project.go
+++ b/internal/app/network/project.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 	"github.com/ktorio/ktor-cli/internal/app"
 	"github.com/ktorio/ktor-cli/internal/app/config"
+	"github.com/ktorio/ktor-cli/internal/app/progress"
+	"github.com/ktorio/ktor-cli/internal/app/utils"
 	"io"
 	"net/http"
 )
@@ -47,7 +49,15 @@ func NewProject(client *http.Client, payload ProjectPayload) ([]byte, error) {
 
 	defer resp.Body.Close()
 
-	bodyBytes, err := io.ReadAll(resp.Body)
+	reader, progressBar := progress.NewReader(
+		resp.Body,
+		"Downloading project archive... ",
+		utils.ContentLength(resp),
+		true,
+	)
+	defer progressBar.Finish()
+
+	bodyBytes, err := io.ReadAll(reader)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/app/progress/ansi.go
+++ b/internal/app/progress/ansi.go
@@ -1,0 +1,10 @@
+package progress
+
+import (
+	"io"
+)
+
+func clearCurrentLine(w io.Writer) error {
+	_, err := io.WriteString(w, "\033[2K\r")
+	return err
+}

--- a/internal/app/progress/percent.go
+++ b/internal/app/progress/percent.go
@@ -27,12 +27,17 @@ func NewReaderAt(r io.ReaderAt, prefix string, total int, enabled bool) (io.Read
 }
 
 func newPercent(prefix string, total int, enabled bool) *Percent {
+	writer := os.Stderr
 	return &Percent{
 		prefix:  prefix,
 		total:   total,
-		enabled: enabled && term.IsTerminal(int(os.Stdout.Fd())),
-		Writer:  os.Stderr,
+		enabled: enabled && term.IsTerminal(int(writer.Fd())),
+		Writer:  writer,
 	}
+}
+
+func (b *Percent) reset() {
+	b.current = 0
 }
 
 func (b *Percent) Write(p []byte) (n int, err error) {

--- a/internal/app/progress/percent.go
+++ b/internal/app/progress/percent.go
@@ -1,0 +1,74 @@
+package progress
+
+import (
+	"fmt"
+	"github.com/ktorio/ktor-cli/internal/app/utils"
+	"golang.org/x/term"
+	"io"
+	"os"
+)
+
+type Percent struct {
+	enabled bool
+	Writer  io.Writer
+	total   int
+	current int
+	prefix  string
+}
+
+func NewReader(r io.Reader, prefix string, total int, enabled bool) (io.Reader, *Percent) {
+	progressBar := newPercent(prefix, total, enabled)
+	return io.TeeReader(r, progressBar), progressBar
+}
+
+func NewReaderAt(r io.ReaderAt, prefix string, total int, enabled bool) (io.ReaderAt, *Percent) {
+	progressBar := newPercent(prefix, total, enabled)
+	return utils.TeeReaderAt(r, progressBar), progressBar
+}
+
+func newPercent(prefix string, total int, enabled bool) *Percent {
+	return &Percent{
+		prefix:  prefix,
+		total:   total,
+		enabled: enabled && term.IsTerminal(int(os.Stdout.Fd())),
+		Writer:  os.Stderr,
+	}
+}
+
+func (b *Percent) Write(p []byte) (n int, err error) {
+	return b.tick(p)
+}
+
+func (b *Percent) WriteAt(p []byte, _ int64) (n int, err error) {
+	return b.tick(p)
+}
+
+func (b *Percent) tick(p []byte) (n int, err error) {
+	if !b.enabled {
+		return len(p), nil
+	}
+
+	b.current += len(p)
+
+	err = clearCurrentLine(b.Writer)
+	if err != nil {
+		return 0, err
+	}
+
+	fmt.Fprintf(b.Writer, "%s%d%%", b.prefix, int(float32(b.current)/float32(b.total)*100))
+	return len(p), nil
+}
+
+func (b *Percent) Finish() (err error) {
+	if !b.enabled {
+		return nil
+	}
+
+	err = clearCurrentLine(b.Writer)
+	if err != nil {
+		return err
+	}
+
+	fmt.Fprintf(b.Writer, "%s100%%\n", b.prefix)
+	return
+}

--- a/internal/app/progress/percent_test.go
+++ b/internal/app/progress/percent_test.go
@@ -1,0 +1,131 @@
+package progress
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+	"unicode"
+)
+
+func TestWrites(t *testing.T) {
+	var b strings.Builder
+	checkAllWrites(t, &Percent{prefix: "___", total: 5, enabled: true, Writer: &b}, &b, []testCase{
+		{writeLen: 1, expected: withClearLine("___20%")},
+		{writeLen: 1, expected: withClearLine("___40%")},
+		{writeLen: 1, expected: withClearLine("___60%")},
+		{writeLen: 1, expected: withClearLine("___80%")},
+		{writeLen: 1, expected: withClearLine("___100%")},
+	})
+
+	checkAllWrites(t, &Percent{prefix: "", total: 3, enabled: true, Writer: &b}, &b, []testCase{
+		{writeLen: 1, expected: withClearLine("33%")},
+		{writeLen: 1, expected: withClearLine("66%")},
+		{writeLen: 1, expected: withClearLine("100%")},
+	})
+
+	checkAllWrites(t, &Percent{prefix: "", total: 3, enabled: true, Writer: &b}, &b, []testCase{
+		{writeLen: 1, expected: withClearLine("33%")},
+		{writeLen: 1, expected: withClearLine("66%")},
+		{writeLen: 1, expected: withClearLine("100%")},
+		{writeLen: -1, expected: withClearLine("100%\n")},
+	})
+
+	checkAllWrites(t, &Percent{prefix: "", total: 10, enabled: true, Writer: &b}, &b, []testCase{
+		{writeLen: 3, expected: withClearLine("30%")},
+		{writeLen: 3, expected: withClearLine("60%")},
+		{writeLen: 3, expected: withClearLine("90%")},
+		{writeLen: -1, expected: withClearLine("100%\n")},
+	})
+
+	checkAllWrites(t, &Percent{prefix: "", total: 10, enabled: false, Writer: &b}, &b, []testCase{
+		{writeLen: 3, expected: ""},
+		{writeLen: 3, expected: ""},
+		{writeLen: 3, expected: ""},
+		{writeLen: -1, expected: ""},
+	})
+
+	checkAllWrites(t, &Percent{prefix: "___", total: 5, enabled: true, Writer: &b}, &b, []testCase{
+		{writeLen: 1, offset: 0, expected: withClearLine("___20%")},
+		{writeLen: 1, offset: 1, expected: withClearLine("___40%")},
+		{writeLen: 1, offset: 2, expected: withClearLine("___60%")},
+		{writeLen: 1, offset: 3, expected: withClearLine("___80%")},
+		{writeLen: 1, offset: 4, expected: withClearLine("___100%")},
+	})
+
+	checkAllWrites(t, &Percent{prefix: "___", total: 100, enabled: true, Writer: &b}, &b, []testCase{
+		{writeLen: 20, offset: 0, expected: withClearLine("___20%")},
+		{writeLen: 20, offset: 40, expected: withClearLine("___40%")},
+		{writeLen: 20, offset: 80, expected: withClearLine("___60%")},
+		{writeLen: 20, offset: 20, expected: withClearLine("___80%")},
+		{writeLen: 20, offset: 60, expected: withClearLine("___100%")},
+	})
+
+	checkAllWrites(t, &Percent{prefix: "", total: 3, enabled: true, Writer: &b}, &b, []testCase{
+		{writeLen: 1, offset: 0, expected: withClearLine("33%")},
+		{writeLen: 1, offset: 1, expected: withClearLine("66%")},
+		{writeLen: 1, offset: 2, expected: withClearLine("100%")},
+		{writeLen: -1, offset: 0, expected: withClearLine("100%\n")},
+	})
+}
+
+type testCase struct {
+	writeLen int
+	offset   int64
+	expected string
+}
+
+func checkAllWrites(t *testing.T, p *Percent, b *strings.Builder, cases []testCase) {
+	for _, test := range cases {
+		var err error
+		if test.writeLen == -1 {
+			err = p.Finish()
+		} else {
+			_, err = p.Write(make([]byte, test.writeLen))
+		}
+
+		assert(t, test.expected, err, b)
+
+		b.Reset()
+	}
+
+	p.reset()
+
+	for _, test := range cases {
+		var err error
+		if test.writeLen == -1 {
+			err = p.Finish()
+		} else {
+			_, err = p.WriteAt(make([]byte, test.writeLen), test.offset)
+		}
+
+		assert(t, test.expected, err, b)
+
+		b.Reset()
+	}
+}
+
+func assert(t *testing.T, expected string, err error, b *strings.Builder) {
+	if err != nil {
+		t.Fatalf("unexpected error %v", err)
+	}
+
+	if expected != b.String() {
+		t.Fatalf("expected %s, got %s", esc(expected), esc(b.String()))
+	}
+}
+
+func withClearLine(s string) string {
+	return fmt.Sprintf("\u001B[2K\r%s", s)
+}
+
+func esc(s string) string {
+	var b strings.Builder
+	for _, r := range s {
+		if !unicode.IsGraphic(r) {
+			b.WriteString(fmt.Sprintf("\\u00%02d", r))
+		} else {
+			b.WriteRune(r)
+		}
+	}
+	return b.String()
+}

--- a/internal/app/utils/io.go
+++ b/internal/app/utils/io.go
@@ -1,0 +1,23 @@
+package utils
+
+import "io"
+
+func TeeReaderAt(r io.ReaderAt, w io.WriterAt) io.ReaderAt {
+	return &teeReaderAt{r, w}
+}
+
+type teeReaderAt struct {
+	r io.ReaderAt
+	w io.WriterAt
+}
+
+func (t *teeReaderAt) ReadAt(p []byte, off int64) (n int, err error) {
+	n, err = t.r.ReadAt(p, off)
+
+	if n > 0 {
+		if n, err := t.w.WriteAt(p[:n], off); err != nil {
+			return n, err
+		}
+	}
+	return
+}

--- a/internal/app/utils/response.go
+++ b/internal/app/utils/response.go
@@ -1,0 +1,16 @@
+package utils
+
+import (
+	"net/http"
+	"strconv"
+)
+
+func ContentLength(resp *http.Response) int {
+	if cl := resp.Header.Get("Content-Length"); cl != "" {
+		if l, err := strconv.Atoi(cl); err == nil {
+			return l
+		}
+	}
+
+	return 0
+}


### PR DESCRIPTION
Shows progress percentage while downloading/extracting project archive and downloading/extracting JDK. This may be useful for users with a slow internet connection.
The progress is disabled when no terminal is detected.