### PR TITLE
Create and use a temp directory within the tool directory

### DIFF
--- a/internal/app/cli/command/generate.go
+++ b/internal/app/cli/command/generate.go
@@ -42,7 +42,7 @@ func Generate(client *http.Client, projectDir, projectName string, verboseLogger
 	fmt.Printf("Project \"%s\" has been created in the directory %s.\n", projectName, projectDir)
 
 	if jh, ok := jdk.JavaHome(); ok {
-		if v, err := jdk.GetJavaMajorVersion(jh); err == nil && v >= jdk.MinJavaVersion {
+		if v, err := jdk.GetJavaMajorVersion(jh, homeDir); err == nil && v >= jdk.MinJavaVersion {
 			fmt.Printf("JDK is detected in JAVA_HOME=%s\n", jh)
 			cli.PrintCommands(projectName, true, "")
 			os.Exit(0)

--- a/internal/app/config/env.go
+++ b/internal/app/config/env.go
@@ -27,6 +27,10 @@ func JdksDir(homeDir string) string {
 	return filepath.Join(KtorDir(homeDir), "jdks")
 }
 
+func TempDir(homeDir string) string {
+	return filepath.Join(KtorDir(homeDir), "temp")
+}
+
 func ktorConfigPath(homeDir string) string {
 	return filepath.Join(KtorDir(homeDir), "config.json")
 }


### PR DESCRIPTION
Snap doesn't allow using the global temp directory, so the temp directory is created within the tool's home directory.