### PR TITLE
Add env variable for AWS Corretto base URL

### DIFF
--- a/internal/app/config/env.go
+++ b/internal/app/config/env.go
@@ -6,13 +6,19 @@ import (
 )
 
 func GenBaseUrl() string {
-	envUrl := os.Getenv("GEN_BASEURL")
-
-	if len(envUrl) == 0 {
-		return "https://ktor-plugin.europe-north1-gke.intellij.net"
+	if e, ok := os.LookupEnv("GEN_BASEURL"); ok && e != "" {
+		return e
 	}
 
-	return envUrl
+	return "https://ktor-plugin.europe-north1-gke.intellij.net"
+}
+
+func CorrettoBaseUrl() string {
+	if e, ok := os.LookupEnv("CORRETTO_BASEURL"); ok && e != "" {
+		return e
+	}
+
+	return "https://corretto.aws"
 }
 
 func KtorDir(homeDir string) string {

--- a/internal/app/jdk/download.go
+++ b/internal/app/jdk/download.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"github.com/ktorio/ktor-cli/internal/app"
+	"github.com/ktorio/ktor-cli/internal/app/config"
 	"github.com/ktorio/ktor-cli/internal/app/progress"
 	"github.com/ktorio/ktor-cli/internal/app/utils"
 	"io"
@@ -21,7 +22,7 @@ func DownloadJdk(client *http.Client, d *Descriptor, logger *log.Logger) ([]byte
 		ext = "zip"
 	}
 
-	url := fmt.Sprintf("https://corretto.aws/downloads/latest/amazon-corretto-%s-%s-%s-jdk.%s", d.Version, d.Arch, d.Platform, ext)
+	url := fmt.Sprintf("%s/downloads/latest/amazon-corretto-%s-%s-%s-jdk.%s", config.CorrettoBaseUrl(), d.Version, d.Arch, d.Platform, ext)
 	logger.Printf("Downloading %s from %s\n", d, url)
 
 	resp, err := client.Get(url)

--- a/internal/app/jdk/verify.go
+++ b/internal/app/jdk/verify.go
@@ -5,6 +5,7 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"github.com/ktorio/ktor-cli/internal/app/config"
 	"io"
 	"log"
 	"net/http"
@@ -20,7 +21,7 @@ func Verify(client *http.Client, d *Descriptor, r io.Reader, logger *log.Logger)
 		ext = "zip"
 	}
 
-	url := fmt.Sprintf("https://corretto.aws/downloads/latest_sha256/amazon-corretto-%s-%s-%s-jdk.%s", d.Version, d.Arch, d.Platform, ext)
+	url := fmt.Sprintf("%s/downloads/latest_sha256/amazon-corretto-%s-%s-%s-jdk.%s", config.CorrettoBaseUrl(), d.Version, d.Arch, d.Platform, ext)
 	logger.Printf("Verifying %s...\n", d)
 
 	resp, err := client.Get(url)


### PR DESCRIPTION
Make testing easier by being able to replace the base URL of the Corretto AWS server. 